### PR TITLE
Fix "Pop problem"

### DIFF
--- a/TICoordinatorKit/Classes/Routable/Stack/StackRoutable.swift
+++ b/TICoordinatorKit/Classes/Routable/Stack/StackRoutable.swift
@@ -31,10 +31,15 @@ public protocol StackRoutable: ModalRoutable {
     var topModule: Presentable? { get }
 
     func push(_ module: Presentable?)
+    func push(_ module: Presentable?,
+                     completion: (() -> ())?)
     func push(_ module: Presentable?, animated: Bool)
     func push(_ module: Presentable?,
               animated: Bool,
               configurationClosure: ConfigurationClosure?)
+    func push(_ module: Presentable?,
+              animated: Bool,
+              completion: (() -> ())?)
     
     func push(_ module: Presentable?,
               animated: Bool,

--- a/TICoordinatorKit/Classes/Routable/Stack/StackRouter.swift
+++ b/TICoordinatorKit/Classes/Routable/Stack/StackRouter.swift
@@ -57,6 +57,12 @@ open class StackRouter: NSObject, StackRoutable, UINavigationControllerDelegate 
         push(module, animated: true)
     }
 
+    public func push(_ module: Presentable?,
+                     completion: (() -> ())?) {
+
+        push(module, animated: true, completion: completion)
+    }
+
     public func push(_ module: Presentable?, animated: Bool) {
         push(module, animated: animated, configurationClosure: nil, completion: nil)
     }
@@ -68,7 +74,12 @@ open class StackRouter: NSObject, StackRoutable, UINavigationControllerDelegate 
         push(module, animated: animated, configurationClosure: configurationClosure, completion: nil)
     }
     
-    
+    public func push(_ module: Presentable?,
+                     animated: Bool,
+                     completion: (() -> ())?) {
+
+        push(module, animated: animated, configurationClosure: nil, completion: completion)
+    }
 
     public func push(_ module: Presentable?,
                      animated: Bool,

--- a/TICoordinatorKit/Classes/Routable/Stack/StackRouter.swift
+++ b/TICoordinatorKit/Classes/Routable/Stack/StackRouter.swift
@@ -22,7 +22,7 @@
 
 import UIKit
 
-open class StackRouter: StackRoutable {
+open class StackRouter: NSObject, StackRoutable, UINavigationControllerDelegate {
 
     private var completions: [UIViewController: () -> ()]
 
@@ -45,6 +45,10 @@ open class StackRouter: StackRoutable {
         self.rootController = rootController
         self.headModule = rootController.topViewController
         self.completions = [:]
+
+        super.init()
+
+        self.rootController?.delegate = self
     }
 
     // MARK: - StackRoutable
@@ -200,10 +204,19 @@ open class StackRouter: StackRoutable {
         completions[controller]?()
         completions.removeValue(forKey: controller)
     }
-
+    
     public func runCompletionsChain(of controllers: [UIViewController]) {
         controllers.forEach { [weak self] controller in
             self?.runCompletion(for: controller)
         }
+    }
+    
+    public func navigationController(_ navigationController: UINavigationController, didShow viewController: UIViewController, animated: Bool) {
+        guard let poppedViewController = navigationController.transitionCoordinator?.viewController(forKey: .from),
+              !navigationController.viewControllers.contains(poppedViewController) else {
+            return
+        }
+        
+        runCompletion(for: poppedViewController)
     }
 }


### PR DESCRIPTION
"Pop problem" - pressing the "back" button of the navigation controller closes the screen, but the coordinator isn't destroyed

Example: The first flow screen must be added like this

router.push(module) { [weak self] in
            self?.finishFlow()
        }